### PR TITLE
Change default to 0 for num uses

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,4 +1,6 @@
 class Booking < ApplicationRecord
   belongs_to :item
   belongs_to :user
+  validates :start_date, :days, :user_id, :item_id, presence: true
+  validates :days, numericality: { only_integer: true }
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,0 +1,4 @@
+class Booking < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,3 @@
+class Item < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,5 @@
 class Item < ApplicationRecord
   belongs_to :user
+  validates :name, :size, :gender, :available, :price, :initial_condition, :brand, :num_uses, presence: true
+  validates :available, inclusion: { in: [true, false] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :items
+  validates :email, presence: true, uniqueness: true
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20201116175220_create_items.rb
+++ b/db/migrate/20201116175220_create_items.rb
@@ -1,0 +1,18 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.string :name
+      t.string :type
+      t.integer :size
+      t.string :gender
+      t.boolean :available
+      t.integer :price
+      t.string :brand
+      t.string :initial_condition
+      t.integer :num_uses
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201116182332_create_bookings.rb
+++ b/db/migrate/20201116182332_create_bookings.rb
@@ -1,0 +1,12 @@
+class CreateBookings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :bookings do |t|
+      t.string :start_date
+      t.string :days
+      t.references :item, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201116200658_change_days_to_be_integer_in_bookings.rb
+++ b/db/migrate/20201116200658_change_days_to_be_integer_in_bookings.rb
@@ -1,0 +1,5 @@
+class ChangeDaysToBeIntegerInBookings < ActiveRecord::Migration[6.0]
+  def change
+    change_column :bookings, :days, :integer, using: 'days::integer'
+  end
+end

--- a/db/migrate/20201116201838_change_start_date_to_be_date_in_bookings.rb
+++ b/db/migrate/20201116201838_change_start_date_to_be_date_in_bookings.rb
@@ -1,0 +1,5 @@
+class ChangeStartDateToBeDateInBookings < ActiveRecord::Migration[6.0]
+  def change
+    change_column :bookings, :start_date, :date, using: 'start_date::date'
+  end
+end

--- a/db/migrate/20201116210522_change_num_uses_default_to_0_in_items.rb
+++ b/db/migrate/20201116210522_change_num_uses_default_to_0_in_items.rb
@@ -1,0 +1,5 @@
+class ChangeNumUsesDefaultTo0InItems < ActiveRecord::Migration[6.0]
+  def change
+    change_column :items, :num_uses, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_174927) do
+ActiveRecord::Schema.define(version: 2020_11_16_175220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "items", force: :cascade do |t|
+    t.string "name"
+    t.string "type"
+    t.integer "size"
+    t.string "gender"
+    t.boolean "available"
+    t.integer "price"
+    t.string "brand"
+    t.string "initial_condition"
+    t.integer "num_uses"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +43,5 @@ ActiveRecord::Schema.define(version: 2020_11_16_174927) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "items", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_182332) do
+ActiveRecord::Schema.define(version: 2020_11_16_200658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "bookings", force: :cascade do |t|
     t.string "start_date"
-    t.string "days"
+    t.integer "days"
     t.bigint "item_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_201838) do
+ActiveRecord::Schema.define(version: 2020_11_16_210522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_201838) do
     t.integer "price"
     t.string "brand"
     t.string "initial_condition"
-    t.integer "num_uses"
+    t.integer "num_uses", default: 0
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_200658) do
+ActiveRecord::Schema.define(version: 2020_11_16_201838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "bookings", force: :cascade do |t|
-    t.string "start_date"
+    t.date "start_date"
     t.integer "days"
     t.bigint "item_id", null: false
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_175220) do
+ActiveRecord::Schema.define(version: 2020_11_16_182332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookings", force: :cascade do |t|
+    t.string "start_date"
+    t.string "days"
+    t.bigint "item_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_bookings_on_item_id"
+    t.index ["user_id"], name: "index_bookings_on_user_id"
+  end
 
   create_table "items", force: :cascade do |t|
     t.string "name"
@@ -43,5 +54,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_175220) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookings", "items"
+  add_foreign_key "bookings", "users"
   add_foreign_key "items", "users"
 end

--- a/test/models/booking_test.rb
+++ b/test/models/booking_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BookingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Decided to alter the schema to include a default of 0 for number of uses. For two reasons:

Firstly, the assumption is that a newly added item would have been used 0 times within the DressCode platform. We could increment this value on every successful booking cycle.

Secondly, it would be useful for validation purposes to ensure this field is populated with a value.