### PR TITLE
Added javascript onclick scroll feature to banner button bypassing bug with filter feature

### DIFF
--- a/app/assets/stylesheets/components/_landing.scss
+++ b/app/assets/stylesheets/components/_landing.scss
@@ -77,6 +77,7 @@ animation-delay: 0
   padding: 10px 30px;
   transition: all 0.2s;
   color: #FFFFFF;
+  cursor: pointer;
 }
 
 #landing-button:hover {

--- a/app/views/items/_banner.html.erb
+++ b/app/views/items/_banner.html.erb
@@ -5,6 +5,6 @@
     <div class="hero-text">
       <h1 class="mb-4">DressCode</h1>
       <%# <p>A LUMS Project blah blah whatever</p> %>
-      <a id="landing-button" href="#items">Find your Cinderella Moment</a>
+      <a onclick="smoothScroll('items')" id="landing-button">Find your Cinderella Moment</a>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,5 +18,14 @@
       <p class="notice"><%= notice %></p>
       <p class="alert"><%= alert %></p>
       <%= render 'shared/flashes' %>
+      <script type="text/javascript">
+        const smoothScroll = (elementId) => {
+          var element = document.getElementById(elementId);
+          element.scrollIntoView({
+            block: 'start',
+            behavior: 'smooth'
+          });
+        };
+      </script>
   </body>
 </html>


### PR DESCRIPTION
The filter feature would not function on click of landing page button due to its redirect to items#items url. I implemented some javascript on the application.html.erb to bypass this fault and implemented it with the button.

BEFORE: URL produced on click to scroll to the item cards:
<img width="1061" alt="Screenshot 2020-11-19 at 19 54 46" src="https://user-images.githubusercontent.com/69588585/99717303-27c11a80-2aa1-11eb-814d-cdd657b3cdc2.png">

AFTER: No redirect URL is produced on click:
<img width="834" alt="Screenshot 2020-11-19 at 19 56 56" src="https://user-images.githubusercontent.com/69588585/99717571-7a023b80-2aa1-11eb-8904-b1e99c3dce6f.png">

Issue moving forward from this implementation: I was unable to import the javascript into the application via the application.js. For the time being, I've placed it in the application.html.erb (see image below). This will need refactoring -- will talk a TA about this.

<img width="484" alt="Screenshot 2020-11-19 at 19 59 38" src="https://user-images.githubusercontent.com/69588585/99717844-dc5b3c00-2aa1-11eb-9b5d-2e79015bf07d.png">
 
