### PR TITLE
Added transparency to the navbar and isolated css selectors for font and stylings on Friday.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,8 @@ html {
 
 body {
   height: 100vh;
+  overflow: overlay;
+
 }
 
 .container {

--- a/app/assets/stylesheets/components/_landing.scss
+++ b/app/assets/stylesheets/components/_landing.scss
@@ -65,7 +65,7 @@ animation-delay: 0
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: white;
+  color: #E0E1E1;
 }
 
 
@@ -85,6 +85,6 @@ animation-delay: 0
   border-color: #FFFFFF;
   background-color: #000000;
   letter-spacing: 0.05em;
-  color: white;
+  color: #E0E1E1;
   text-decoration: none;
 }

--- a/app/assets/stylesheets/components/_landing.scss
+++ b/app/assets/stylesheets/components/_landing.scss
@@ -4,13 +4,14 @@
 
   /* set a height and width for the hero image */
   width: 100vw;
-  height: 91.5vh;
+  height: 100vh;
 
   /* positioning */
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   position: relative;
+  bottom: 72px;
 }
 
 @keyframes FadeInOut {
@@ -33,7 +34,7 @@
   background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4));
   position: absolute;
   width: 100vw;
-  height: 91.5vh;
+  height: 100vh;
   transition: opacity 0.5s ease-in-out;
   animation-name: FadeInOut;
   animation-timing-function: ease-in-out;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,6 +1,7 @@
 .navbar-lewagon {
   justify-content: space-between;
-  background: rbga(255,255,255,1);
+  background: transparent;
+  z-index: 2;
 }
 
 .navbar-lewagon .navbar-collapse {
@@ -9,4 +10,8 @@
 
 .navbar-lewagon .navbar-brand img {
   width: 70px;
+}
+
+.navbar-light .navbar-nav .nav-link {
+  color: white;
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,4 +1,5 @@
 .navbar-lewagon {
+  background-color: purple;
   justify-content: space-between;
   background: transparent;
   z-index: 2;
@@ -13,5 +14,17 @@
 }
 
 .navbar-light .navbar-nav .nav-link {
-  color: white;
+  // font-family: $body-font;
+  font-family: $headers-font;
+  color: #E0E1E1;
+  font-weight: 300;
+  border-left: 1px solid #C58916;
+  transition: all 0.5s linear;
+}
+
+.navbar-light .navbar-nav .nav-link:hover {
+  color: #D9DDDC;
+  letter-spacing: 1px;
+  font-weight: 700;
+  border-left: 2px solid #DAA400;
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <%= link_to items_path, class: "navbar-brand" do %>
-    <%= image_tag("dresscodelogo.jpg.png") %>
+    <%= image_tag("dresscodelogo-transparent.png") %>
     <% end %>
 
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -17,7 +17,7 @@
           <%= link_to "Post an Item", new_item_path, class: "nav-link" %>
         </li>
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%=current_user.email%></a>  
+          <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%=current_user.email%></a>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="#">My Bookings</a>
             <a class="dropdown-item" href="#">My Items</a>


### PR DESCRIPTION
This update is now the stylistic foundation for the landing screen and navbar. I have adjusted the background images (with animation) to encompass 100% of the viewer height. I have swapped the logo for a transparent png that I made from Anneliese's design and integrated this into our transparent navbar see below:
<img width="1439" alt="Screenshot 2020-11-19 at 21 17 36" src="https://user-images.githubusercontent.com/69588585/99725244-b7b89180-2aac-11eb-9a7a-1638c4209144.png">

Next steps:
1. Set two legible font colours (one as standard, one for hover) using the font families select by Ziyad.
2a. Add static styling to the link buttons to signpost users to their functionality.
2b. Add animated styling to the link buttons to provide a visual response to hover.
3. Add a subtle linear gradient that gets slightly darker towards the top of the page in order to denote the navbar space.
4. Add subtle borders between buttons and logo to indicate button space and make them visually responsive.

All of this is achievable with css. So it shouldn't take much time to implement.